### PR TITLE
minor CSS fixes already

### DIFF
--- a/demo-pages-shared-styles.html
+++ b/demo-pages-shared-styles.html
@@ -67,6 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       demo-snippet.centered-demo {
         --demo-snippet-demo: {
           @apply(--layout-horizontal);
+          @apply(--layout-wrap);
           @apply(--layout-center-justified);
         }
       }

--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -62,6 +62,7 @@ Custom property | Description | Default
 
       .demo {
         border-bottom: 1px solid #e5e5e5;
+        background-color: white;
         margin: 0;
         padding: 20px;
         @apply(--demo-snippet-demo);
@@ -72,7 +73,7 @@ Custom property | Description | Default
         margin: 0;
         background-color: #fafafa;
         font-size: 13px;
-        word-wrap: break-word;
+        overflow: auto;
         @apply(--demo-snippet-code);
       }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,12 +32,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       display: block;
       margin-right: 24px;
     }
-
-    demo-snippet.centered-demo.small-text {
-      --demo-snippet-code: {
-        font-size: 12px;
-      };
-    }
   </style>
 </head>
 <body unresolved>


### PR DESCRIPTION
It landed two hours ago, so here's a PR.

This fixes two minor CSS fixes: instead of wrapping the code around (which looks dumb on small screens), let it scroll. Also, if the demo content is larger than the actual demo div, force it to wrap.

Before:
<img width="129" alt="screen shot 2015-11-30 at 10 19 42 pm" src="https://cloud.githubusercontent.com/assets/1369170/11493783/0edd300e-97b1-11e5-929e-5edd4eb13517.png">

After (this is scrolled midway):
<img width="99" alt="screen shot 2015-11-30 at 10 20 47 pm" src="https://cloud.githubusercontent.com/assets/1369170/11493787/147581ec-97b1-11e5-95e6-89f7c127a915.png">
