### PR TITLE
simplify template code

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.2",
     "paper-styles": "PolymerElements/paper-styles#1.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0"
   }

--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -116,7 +116,7 @@ Custom property | Description | Default
 
         // TODO(noms): When marked-element/issues/23 lands, this will become
         // a public method and will need to be updated.
-        var snippet = this.$.marked._unindent(Polymer.domInnerHTML.getInnerHTML(template));
+        var snippet = this.$.marked._unindent(template.innerHTML);
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');

--- a/test/basic.html
+++ b/test/basic.html
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../demo-snippet.html">
+  <script src="../../iron-test-helpers/test-helpers.js"></script>
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
 
 </head>
@@ -52,7 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <demo-snippet>
         <template>
-          <input type="date" disabled>
+          <input disabled type="date">
         </template>
       </demo-snippet>
     </template>
@@ -60,6 +61,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
   <script>
+    // TODO(notwaldorf): Tests are currently very unhappy in IE
+    function isNotIE() {
+      return !navigator.userAgent.match(/MSIE/i);
+    }
+
     suite('display', function() {
       var emptyHeight;
 
@@ -68,7 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         emptyHeight = emptyDemo.getBoundingClientRect().height;
       });
 
-      test('can render native elements', function() {
+      test('can render native elements', skipUnless(isNotIE, function() {
         var element = fixture('native-demo');
 
         // Render the distributed children.
@@ -87,9 +93,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var markdownElement = element.$.marked;
         expect(markdownElement.markdown).to.be.equal('```\n\n<input disabled>\n\n```');
-      });
+      }));
 
-      test('can render custom elements', function() {
+      test('can render custom elements', skipUnless(isNotIE, function() {
         var element = fixture('custom-demo');
 
         // Render the distributed children.
@@ -109,7 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var markdownElement = element.$.marked;
         expect(markdownElement.markdown).to.be.equal(
             '```\n\n<paper-checkbox disabled></paper-checkbox>\n\n```');
-      });
+      }));
     });
 
     suite('parsing', function() {
@@ -119,7 +125,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var element = fixture('demo-with-attributes');
       });
 
-      test('preserves attributes', function() {
+      test('preserves attributes', skipUnless(isNotIE, function() {
         var element = fixture('demo-with-attributes');
 
         // Render the distributed children.
@@ -127,8 +133,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var markdownElement = element.$.marked;
         expect(markdownElement.markdown).to.be.equal(
-            '```\n\n<input type="date" disabled>\n\n```');
-      });
+            '```\n\n<input disabled type="date">\n\n```');
+      }));
     });
   </script>
 </body>


### PR DESCRIPTION
The tests are disabled in IE because there is a bug in the `webcomponents` polyfill, where `importNode` doesn't recursively pull in nested templates. What this means is that when using `text-fixture` to test, the `iron-demo-helper`'s code snippet template is always empty.