### PR TITLE
fix nested templates

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -114,17 +114,49 @@ Custom property | Description | Default
           return;
         }
 
+        var templateContent = template._content || template.content;
+        this._updateMarkdown(this._getTemplateHTML(templateContent));
+
+        // Stamp the template.
+        Polymer.dom(this).appendChild(document.importNode(templateContent, true));
+      },
+
+      _getTemplateHTML: function(templateContent) {
+        // For nested templates, `innerHTML` doesn't return the right thing,
+        // since template contents are not cloned correctly. In that case,
+        // we need to generate the content from the children.
+        var innerHTML = templateContent.innerHTML;
+
+        if (!innerHTML && templateContent.childNodes.length > 0) {
+          innerHTML = '';
+          for (var i = 0; i < templateContent.childNodes.length; i++ ) {
+            var child = templateContent.childNodes[i];
+
+            if (child.nodeType === Node.TEXT_NODE) {
+              // We need to save the contents of text nodes to maintain the
+              // correct indentation.
+              innerHTML += child.textContent;
+            } else if (child.nodeType === Node.COMMENT_NODE) {
+              // Comment nodes have a terrible api.
+              innerHTML += '<!--' + child.textContent + '-->';
+            } else {
+              innerHTML += child.outerHTML;
+            }
+          }
+        }
+
+        return innerHTML;
+      },
+
+      _updateMarkdown: function(innerHTML) {
         // TODO(noms): When marked-element/issues/23 lands, this will become
         // a public method and will need to be updated.
-        var snippet = this.$.marked._unindent(template.innerHTML);
+        var snippet = this.$.marked._unindent(innerHTML);
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');
 
         this._markdown = '```\n' + snippet + '\n' + '```';
-
-        // Stamp the template.
-        Polymer.dom(this).appendChild(document.importNode(template.content, true));
       }
     });
   </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -59,9 +59,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="nested-templates">
+    <template>
+      <demo-snippet id="nestedDemo">
+        <template>
+          <template is="dom-bind">
+            <template is="dom-repeat" items='["one", "two"]'>
+              <input value="[[item]]">
+            </template>
+          </template>
+        </template>
+      </demo-snippet>
+    </template>
+  </test-fixture>
 
   <script>
-    // TODO(notwaldorf): Tests are currently very unhappy in IE
+    // TODO(notwaldorf): Tests are currently very unhappy in IE because
+    // the webcomponents polyfill does not handle the nested template
+    // inside the test-fixture correctly.
     function isNotIE() {
       return !navigator.userAgent.match(/MSIE/i);
     }
@@ -115,6 +130,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var markdownElement = element.$.marked;
         expect(markdownElement.markdown).to.be.equal(
             '```\n\n<paper-checkbox disabled></paper-checkbox>\n\n```');
+      }));
+
+      test('can render elements inside a nested template', skipUnless(isNotIE, function() {
+        var f = fixture('nested-templates');
+        var element = document.querySelector('#nestedDemo');
+
+        // Render the distributed children.
+        Polymer.dom.flush();
+
+        var rect = element.getBoundingClientRect();
+        expect(rect.height).to.be.greaterThan(emptyHeight);
+
+        // The demo is rendered in the light dom, so it should exist, and
+        // it should respect the demo element's attributes, and not make up
+        // new ones.
+        var inputs = Polymer.dom(element).querySelectorAll('input')
+        expect(inputs).to.be.ok;
+        expect(inputs.length).to.be.equal(2);
+        expect(inputs[0].value).to.be.equal('one');
+        expect(inputs[1].value).to.be.equal('two');
+
+        var code = element.$.marked.markdown;
+
+        // There's a lot of text in there, so rather than doing a string
+        // comparison, look for the things you care about
+        expect((code.match(/<template is="dom-bind">/g) || []).length).to.be.equal(1);
+        expect((code.match(/<template is="dom-repeat"/g) || []).length).to.be.equal(1);
+        expect((code.match(/<\/template>/g) || []).length).to.be.equal(2);
+        expect((code.match(/input/g) || []).length).to.be.equal(1);
       }));
     });
 


### PR DESCRIPTION
If the `demo-snippet` is inside another template, like this:
```html
<template is="dom-bind">
  <demo-snippet>
    <template>
          <input>
    </template>
  </demo-snippet>
</template>
```
then the `demo-snippet`'s inside template is empty, because of how `cloneNode` works with templates. In this case we need to a) use Polymer's `template._content`, to actually get the nested content, and b) manually generate the `innerHTML`, since that works on the original template which is empty

💥😂🔫 

Also, I've moved the code into separate functions because it was getting out of control