### PR TITLE
add copy to clipboard functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,9 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.1.0",
+    "iron-icons": "PolymerElements/iron-icons#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "marked-element": "polymerelements/marked-element#^1.0.0",
     "prism-element": "PolymerElements/prism-element#^1.0.0"
   },

--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -9,11 +9,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../marked-element/marked-element.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/shadow.html">
-
+<link rel="import" href="../prism-element/prism-highlighter.html">
 
 <!--
 `demo-snippet` is a helper element that displays the source of a code snippet and
@@ -61,7 +62,7 @@ Custom property | Description | Default
       }
 
       .demo {
-        border-bottom: 1px solid #e5e5e5;
+        border-bottom: 1px solid var(--google-grey-300);
         background-color: white;
         margin: 0;
         padding: 20px;
@@ -71,7 +72,7 @@ Custom property | Description | Default
       .code {
         padding: 0 20px;
         margin: 0;
-        background-color: #fafafa;
+        background-color: var(--google-grey-100);
         font-size: 13px;
         overflow: auto;
         @apply(--demo-snippet-code);
@@ -81,6 +82,17 @@ Custom property | Description | Default
         margin: 0;
         padding: 0 0 10px 0;
       }
+
+      .code-container {
+        position: relative;
+      }
+
+      paper-icon-button {
+        position: absolute;
+        top: 0;
+        right: 0px;
+      }
+
     </style>
 
     <prism-highlighter></prism-highlighter>
@@ -89,12 +101,22 @@ Custom property | Description | Default
       <content id="content"></content>
     </div>
 
-    <marked-element markdown=[[_markdown]] id="marked">
-      <div class="markdown-html code"></div>
-    </marked-element>
+    <div class="code-container">
+      <marked-element markdown=[[_markdown]] id="marked">
+        <div class="markdown-html code" id="code"></div>
+      </marked-element>
+      <paper-icon-button
+          id="copyButton"
+          icon="content-copy"
+          title="copy to clipboard"
+          on-tap="_copyToClipboard">
+      </paper-icon-button>
+    </div>
   </template>
 
   <script>
+    'use strict';
+
     Polymer({
       is: 'demo-snippet',
 
@@ -123,6 +145,34 @@ Custom property | Description | Default
 
         // Stamp the template.
         Polymer.dom(this).appendChild(document.importNode(template.content, true));
+      },
+
+      _copyToClipboard: function() {
+        // From https://github.com/google/material-design-lite/blob/master/docs/_assets/snippets.js
+        var snipRange = document.createRange();
+        snipRange.selectNodeContents(this.$.code);
+        var selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(snipRange);
+        var result = false;
+        try {
+          result = document.execCommand('copy');
+          this.$.copyButton.icon = 'done';
+        } catch (err) {
+          // Copy command is not available
+          console.error(err);
+          this.$.copyButton.icon = 'error';
+        }
+
+        // Return to the copy button after a second.
+        setTimeout(this._resetCopyButtonState.bind(this), 1000);
+
+        selection.removeAllRanges();
+        return result;
+      },
+
+      _resetCopyButtonState: function() {
+        this.$.copyButton.icon = 'content-copy';
       }
     });
   </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             --paper-checkbox-unchecked-ink-color: var(--paper-red-900);
             --paper-checkbox-label-color: var(--paper-red-500);
           }
-          </style>
+        </style>
 
         <paper-checkbox class="blue">Checkbox</paper-checkbox>
         <paper-checkbox checked class="red">Checkbox</paper-checkbox>


### PR DESCRIPTION
I blatantly stole the copy-to-clipboard functionality from MDL (thanks @addyosmani!) and added it to this element. Unlike MDL, though, I made it as a separate button (vs. allowing a click anywhere to count as a copy). I figured if we add another button for live edits in the future, it might make it easier to not change this again.

It looks like this. The button reverts state once you hover/blur away from it. (this gif is a bummer and the compression loses the code background colour)
![copy2](https://cloud.githubusercontent.com/assets/1369170/12529586/3cd4a58e-c171-11e5-9f8e-110bd322851c.gif)

This is what it looks like when it's not doing anything because that gif is a potato:
<img width="524" alt="screen shot 2016-01-23 at 1 30 42 am" src="https://cloud.githubusercontent.com/assets/1369170/12529578/f0780b0e-c170-11e5-9fc4-845d91c7084d.png">

Note that I used the "paste" icon (because I thought it inspired a clipboard) more than the "copy" icon, which is this:
<img width="114" alt="screen shot 2016-01-23 at 1 36 27 am" src="https://cloud.githubusercontent.com/assets/1369170/12529593/bd399eb4-c171-11e5-992d-2047a4752958.png">

I don't really have an opinion. Neither of those icons make sense to me :(

I also changed the hardcoded colours to their paper equivalents because why not.
🎈 