### PR TITLE
fix button overlapping text

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -70,7 +70,7 @@ Custom property | Description | Default
       }
 
       .code {
-        padding: 0 20px;
+        padding: 20px;
         margin: 0;
         background-color: var(--google-grey-100);
         font-size: 13px;


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-demo-helpers/issues/15.
I just added a padding to the code, so that the button never overlaps it.

The other alternative was shrinking the scrollable area, but I found that having the bottom scrollbar only covering 90% of the code looked kind of ugly (personal opinion, easily changed)
<img width="524" alt="screen shot 2016-02-17 at 12 50 24 pm" src="https://cloud.githubusercontent.com/assets/1369170/13124234/13a4242e-d575-11e5-8070-0c3154c69b11.png">



Normal case:
<img width="530" alt="screen shot 2016-02-17 at 12 46 38 pm" src="https://cloud.githubusercontent.com/assets/1369170/13124155/ae57e52e-d574-11e5-8a7c-e2589513c4b6.png">

Overlap case:
<img width="522" alt="screen shot 2016-02-17 at 12 44 10 pm" src="https://cloud.githubusercontent.com/assets/1369170/13124159/b1b9d74a-d574-11e5-93d1-537afe71972b.png">

@cdata PTAL 🎈 