### PR TITLE
Add support for using `<template is="dom-bind">` in a `<demo-snippet>`.

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -143,8 +143,12 @@ Custom property | Description | Default
 
         this._markdown = '```\n' + snippet + '\n' + '```';
 
-        // Stamp the template.
-        Polymer.dom(this).appendChild(document.importNode(template.content, true));
+
+        // If the template is dom-bind, it will render itself. Otherwise,
+        // stamp the template.
+        if (template.getAttribute('is') !== 'dom-bind') {
+          Polymer.dom(this).appendChild(document.importNode(template.content, true));
+        }
       },
 
       _copyToClipboard: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -55,6 +55,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </demo-snippet>
 
+  <demo-snippet id="demoWithDomBind">
+    <template is="dom-bind">
+      <paper-checkbox checked="{{checked}}"></paper-checkbox>
+      <div>{{checked}}</div>
+    </template>
+  </demo-snippet>
+
   <script>
     suite('display', function() {
       var emptyHeight;
@@ -107,6 +114,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var markdownElement = element.$.marked;
         expect(markdownElement.markdown).to.be.equal(
             '```\n\n<paper-checkbox disabled></paper-checkbox>\n\n```');
+      });
+
+      test('can render dom-bind templates', function() {
+        var element = document.getElementById('demoWithDomBind');
+
+        // Render the distributed children.
+        Polymer.dom.flush();
+
+        var rect = element.getBoundingClientRect();
+
+        expect(rect.height).to.be.greaterThan(emptyHeight);
+
+        // Make sure that bindings used in the demo work as expected.
+        var checkbox = Polymer.dom(element).querySelector('paper-checkbox');
+        var div = Polymer.dom(element).querySelector('div');
+        expect(div.textContent).to.equal('false');
+        checkbox.checked = true;
+        expect(div.textContent).to.equal('true');
+
+        var markdownElement = element.$.marked;
+        expect(markdownElement.markdown).to.be.equal(
+            '```\n\n<paper-checkbox checked="{{checked}}"></paper-checkbox>\n<div>{{checked}}</div>\n\n```');
       });
     });
 


### PR DESCRIPTION
When creating a `<demo-snippet>`, do not stamp out the template if it has dom-bind as that will cause the demo content to appear twice, once with the bindings and once without.