### PR TITLE
Fix styling with shadow dom enabled

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "marked-element": "polymerelements/marked-element#^1.0.0",
-    "prism-element": "PolymerElements/prism-element#^1.0.0",
+    "prism-element": "PolymerElements/prism-element#^1.1.0",
     "iron-location": "PolymerElements/iron-location#^0.8.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0"
   },

--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/shadow.html">
 <link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../prism-element/prism-theme-default.html">
 
 <!--
 `demo-snippet` is a helper element that displays the source of a code snippet and
@@ -54,6 +55,7 @@ Custom property | Description | Default
 
 <dom-module id="demo-snippet">
   <template>
+    <style is="custom-style" include="prism-theme-default"></style>
     <style>
       :host {
         display: block;


### PR DESCRIPTION
This fixes the styling of the demo-snippet markdown when shadow dom is enabled

Refs #28 
Refs https://github.com/PolymerElements/prism-element/pull/17