### PR TITLE
No longer need to place the code in a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,14 @@ Polymer elements.
 Example of a native element demo
 
     <demo-snippet>
-      <template>
-        <input type="date">
-      </template>
+      <input type="date">
     </demo-snippet>
 
 Example of a Polymer <paper-checkbox> demo
 
     <demo-snippet>
-      <template>
-        <paper-checkbox>Checkbox</paper-checkbox>
-        <paper-checkbox checked>Checkbox</paper-checkbox>
-      </template>
+      <paper-checkbox>Checkbox</paper-checkbox>
+      <paper-checkbox checked>Checkbox</paper-checkbox>
     </demo-snippet>
 ```
 

--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -131,22 +131,16 @@ Custom property | Description | Default
 
       attached: function() {
         var template = Polymer.dom(this).queryDistributedElements('template')[0];
-
-        // If there's no template, render empty code.
-        if (!template) {
-          this._markdown = '```\n```';
-          return;
-        }
-
-        var snippet = this.$.marked.unindent(template.innerHTML);
+        var content =  template || Polymer.dom(this);
+        var snippet = this.$.marked.unindent(content.innerHTML);
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');
 
         this._markdown = '```\n' + snippet + '\n' + '```';
 
-        // Stamp the template.
-        if (!template.is) {
+        // Stamp the content if it is a template without 'is' attribute.
+        if (template && !template.is) {
           Polymer.dom(this).appendChild(document.importNode(template.content, true));
         }
       },

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,42 +38,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <div class="vertical-section-container centered">
     <h4>Demo of a native element</h4>
     <demo-snippet class="centered-demo">
-      <template>
-        <input type="date">
-      </template>
+      <input type="date">
     </demo-snippet>
 
     <h4>Demo of a custom element</h4>
     <demo-snippet class="centered-demo">
-      <template>
-        <paper-checkbox>Checkbox</paper-checkbox>
-        <paper-checkbox checked>Checkbox</paper-checkbox>
-      </template>
+      <paper-checkbox>Checkbox</paper-checkbox>
+      <paper-checkbox checked>Checkbox</paper-checkbox>
     </demo-snippet>
 
     <h4>Demo of an element with custom styles</h4>
     <demo-snippet class="centered-demo small-text">
-      <template>
-        <style is="custom-style">
-          paper-checkbox.blue {
-            --paper-checkbox-checked-color: var(--paper-blue-500);
-            --paper-checkbox-checked-ink-color: var(--paper-blue-500);
-            --paper-checkbox-unchecked-color: var(--paper-blue-900);
-            --paper-checkbox-unchecked-ink-color: var(--paper-blue-900);
-            --paper-checkbox-label-color: var(--paper-blue-500);
-          }
-          paper-checkbox.red {
-            --paper-checkbox-checked-color: var(--paper-red-500);
-            --paper-checkbox-checked-ink-color: var(--paper-red-500);
-            --paper-checkbox-unchecked-color: var(--paper-red-900);
-            --paper-checkbox-unchecked-ink-color: var(--paper-red-900);
-            --paper-checkbox-label-color: var(--paper-red-500);
-          }
-        </style>
+      <style is="custom-style">
+        paper-checkbox.blue {
+          --paper-checkbox-checked-color: var(--paper-blue-500);
+          --paper-checkbox-checked-ink-color: var(--paper-blue-500);
+          --paper-checkbox-unchecked-color: var(--paper-blue-900);
+          --paper-checkbox-unchecked-ink-color: var(--paper-blue-900);
+          --paper-checkbox-label-color: var(--paper-blue-500);
+        }
+        paper-checkbox.red {
+          --paper-checkbox-checked-color: var(--paper-red-500);
+          --paper-checkbox-checked-ink-color: var(--paper-red-500);
+          --paper-checkbox-unchecked-color: var(--paper-red-900);
+          --paper-checkbox-unchecked-ink-color: var(--paper-red-900);
+          --paper-checkbox-label-color: var(--paper-red-500);
+        }
+      </style>
 
-        <paper-checkbox class="blue">Checkbox</paper-checkbox>
-        <paper-checkbox checked class="red">Checkbox</paper-checkbox>
-      </template>
+      <paper-checkbox class="blue">Checkbox</paper-checkbox>
+      <paper-checkbox checked class="red">Checkbox</paper-checkbox>
     </demo-snippet>
 
     <h4>Demo of an element with bindings</h4>

--- a/test/basic.html
+++ b/test/basic.html
@@ -38,21 +38,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <demo-snippet id="emptyDemo"></demo-snippet>
 
   <demo-snippet id="nativeDemo">
-    <template>
-      <input disabled>
-    </template>
+    <input disabled>
   </demo-snippet>
 
   <demo-snippet id="customDemo">
-    <template>
-      <paper-checkbox disabled></paper-checkbox>
-    </template>
+    <paper-checkbox disabled></paper-checkbox>
   </demo-snippet>
 
   <demo-snippet id="demoWithAttributes">
-    <template>
-      <input disabled type="date">
-    </template>
+    <input disabled type="date">
   </demo-snippet>
 
   <demo-snippet id="typeExtensionDemo">


### PR DESCRIPTION
fix #38, it is also a progress for #29 because demo-snippet will render in a `<template>` if it doesn't contain a `<template>`.