### PR TITLE
Auto-wrap snippet scripts to support IE11 and Edge

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -147,8 +147,24 @@ Custom property | Description | Default
 
         // Stamp the template.
         if (!template.is) {
+          var scripts = template.content.querySelectorAll('script');
+          for (var i = 0; i < scripts.length; i++) {
+            if (scripts[i].innerHTML) {
+              scripts[i].innerHTML = this._wrapScript(scripts[i]);
+            }
+          }
           Polymer.dom(this).appendChild(document.importNode(template.content, true));
         }
+      },
+
+      _wrapScript: function(script) {
+        return
+          'window.addEventListener("WebComponentsReady", function() {' +
+            // Async call needed here for IE11/Edge compatibility.
+            'Polymer.Base.async(function() {' +
+              script.innerHTML +
+            '});' +
+          '});';
       },
 
       _copyToClipboard: function() {


### PR DESCRIPTION
To work in IE11 and Microsoft Edge every snippet should be wrapped by:

```js
window.addEventListener('WebComponentsReady', function() {
  // Async call needed here for IE11/Edge compatibility.
  Polymer.Base.async(function() {
    ...
  });
});
```

This PR aimed to get rid of it, so scripts in example snippets won't need to have that ugly wrapper.