### PR TITLE
Remove polylint check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polylint web-component-tester
+  - npm install -g bower web-component-tester
   - bower install
-  - polylint
 node_js: '6'
 addons:
   firefox: latest


### PR DESCRIPTION
`polylint` will always fail because of `iron-icon` package which uses the undocumented `isAttached` property and `polylint` does not handle it properly.