### PR TITLE
Fix marked-element width

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -95,6 +95,10 @@ Custom property | Description | Default
         right: 0px;
       }
 
+      marked-element {
+        display: block;
+      }
+
     </style>
 
     <prism-highlighter></prism-highlighter>


### PR DESCRIPTION
Some changes were made to `marked-element` element and currently there's this issue:

![](https://i.imgur.com/ejfBVN1.png)

As you can see, `marked-element` is not taking whole width of `.code-container`, this PR fixes it:

![](https://i.imgur.com/ei3Omqf.png)