### PR TITLE
fix: Expanded template `is` attribute check.

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -146,7 +146,7 @@ Custom property | Description | Default
         this._markdown = '```\n' + snippet + '\n' + '```';
 
         // Stamp the template.
-        if (!template.is) {
+        if (!template.hasAttribute('is')) {
           Polymer.dom(this).appendChild(document.importNode(template.content, true));
         }
       },


### PR DESCRIPTION
This change expounds on the fix in #32 to prevent duplicate stamping of unresolved `<template is="...">` elements when demo pages are loaded in an `iron-component-page` iframe.

![image](https://cloud.githubusercontent.com/assets/155164/22557006/18c2f72e-e937-11e6-97f8-05ae44c92258.png)
