### PR TITLE
from polymerelements to PolymerElements in 2.0-preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,10 @@
   "homepage": "https://github.com/PolymerElements/iron-demo-helpers",
   "ignore": [],
   "dependencies": {
-    "polymer": "polymer/polymer#^2.0.0-rc.1",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#2.0-preview",
+    "polymer": "Polymer/polymer#^2.0.0-rc.1",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
     "iron-location": "PolymerElements/iron-location#2.0-preview",
-    "marked-element": "polymerelements/marked-element#2.0-preview",
+    "marked-element": "PolymerElements/marked-element#2.0-preview",
     "prism-element": "PolymerElements/prism-element#2.0-preview"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
         "polymer": "Polymer/polymer#^1.5.0",
         "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
         "iron-location": "PolymerElements/iron-location#^0.8.0",
-        "marked-element": "polymerelements/marked-element#^1.0.0",
+        "marked-element": "PolymerElements/marked-element#^1.0.0",
         "prism-element": "PolymerElements/prism-element#^1.1.0"
       },
       "devDependencies": {


### PR DESCRIPTION
his pull request wants to make this Polymer element consistent with the majority of other Polymer elements in the 2.0-preview branch. The uppercase version "PolymerElements" and "Polymer" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I fixed this in the  "2.0-preview" branch of this element, because it would be very nice to have this cleaned up and consistent in 2.0 release. I have manually checked 66 elements that have a "2.0-preview" branch. 56 are ok. This element is one of 10 which has these small differences

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.