### PR TITLE
Fix type errors in iron-demo-helpers

### DIFF
--- a/url-bar.html
+++ b/url-bar.html
@@ -69,13 +69,15 @@ Custom property | Description | Default
       is: 'url-bar',
       properties: {
         url: {
-          computed: '__computeUrl(path, query, hash)'
+          computed: '__computeUrl(path, query, hash)',
+          type: String
         },
         inIframe: {
           value: function() {
             return window.top !== window;
           },
-          reflectToAttribute: true
+          reflectToAttribute: true,
+          type: Boolean
         },
         path: {
           type: String


### PR DESCRIPTION
Added missing type for url and inIframe