### PR TITLE
Remove paddings for .code-container

### DIFF
--- a/demo-snippet.html
+++ b/demo-snippet.html
@@ -77,7 +77,6 @@ Custom property | Description | Default
         font-size: 13px;
         overflow: auto;
         position: relative;
-        padding: 0 20px;
         @apply --demo-snippet-code;
       }
 


### PR DESCRIPTION
This change will remove this useless space on both sides of a code snippet:

![](https://i.imgur.com/qA6zkv1.png)