### PR TITLE
from polymerelements to PolymerElements (again)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
     "font-roboto": "PolymerElements/font-roboto#^1",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#1 - 2",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#1 - 2",
     "iron-location": "PolymerElements/iron-location#1 - 2",
-    "marked-element": "polymerelements/marked-element#1 - 2",
+    "marked-element": "PolymerElements/marked-element#1 - 2",
     "prism-element": "PolymerElements/prism-element#1 - 2"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
         "font-roboto": "PolymerElements/font-roboto#^1",
         "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
         "iron-location": "PolymerElements/iron-location#^0.8.0",
-        "marked-element": "polymerelements/marked-element#^1.0.0",
+        "marked-element": "PolymerElements/marked-element#^1.0.0",
         "prism-element": "PolymerElements/prism-element#^1.1.0"
       },
       "devDependencies": {


### PR DESCRIPTION
This is a follow up of #58 which was on the old 2.0-preview branch.

This pull request wants to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" and "Polymer" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.