### PR TITLE
Adding a dom-ready event fired when the demo-snippet is ready

### DIFF
--- a/demo-snippet.js
+++ b/demo-snippet.js
@@ -172,6 +172,7 @@ Polymer({
       this._observer = null;
       dom(this).appendChild(document.importNode(template.content, true));
     }
+    this.dispatchEvent(new CustomEvent('dom-ready'));
   },
 
   _copyToClipboard: function() {


### PR DESCRIPTION
I need to inject some data in my demos, and to do that I need to be sure that I don't inject them before the `demo-snippet` has created the elements inside `<div id='content'>`.
I am firing a  `dom-ready` event when `demo-snippet` has finished its `_updateMarkdown` method.