### PR TITLE
Documenting `dom-ready` event

### DIFF
--- a/demo-snippet.js
+++ b/demo-snippet.js
@@ -126,6 +126,15 @@ Polymer({
   is: 'demo-snippet',
 
   properties: {
+
+    /**
+     * Fired when the demo-snippet is ready, i.e. when it has injected the code to demo 
+     * in the DOM and it can be interacted with
+     * 
+     * @event dom-ready
+     */
+
+    /** @private */
     _markdown: {
       type: String,
     },


### PR DESCRIPTION
Documenting the `dom-ready` elements using `@event` as in most Polymer Elements